### PR TITLE
Fix for shorter if let lifetime

### DIFF
--- a/examples/object.rs
+++ b/examples/object.rs
@@ -30,9 +30,10 @@ fn main() -> trackable::result::TopLevelResult {
         }
         Op::Ls => {
             for object_path in track!(file.object_paths())? {
+                let tracked_path = track!(object_path)?;
                 println!(
                     "{}",
-                    track_assert_some!(track!(object_path)?.to_str(), trackable::error::Failed)
+                    track_assert_some!(tracked_path.to_str(), trackable::error::Failed)
                 );
             }
         }


### PR DESCRIPTION
Context: Rust compiler PR https://github.com/rust-lang/rust/pull/107251 wants to change the lifetime of things inside the `if let` matcher. The PR would break the build of this project's example (out of only a handful of breakages):

```Rust
error[E0716]: temporary value dropped while borrowed
  --> examples/object.rs:35:40
   |
33 | /                 println!(
34 | |                     "{}",
35 | |                     track_assert_some!(track!(object_path)?.to_str(), trackable::error::Failed)
   | |                     -------------------^^^^^^^^^^^^^^^^^^^^------------------------------------
   | |                     |                  |
   | |                     |                  creates a temporary value which is freed while still in use
   | |                     temporary value is freed at the end of this statement
36 | |                 );
   | |_________________- borrow later used here
   |
   = note: consider using a `let` binding to create a longer lived value
```

The new version compiles both before and after the PR. Thanks for taking a look!